### PR TITLE
Ensure plugin passes all Plugin Check categories

### DIFF
--- a/hello.php
+++ b/hello.php
@@ -59,9 +59,9 @@ function hello_dolly() {
 
 	printf(
 		'<p id="dolly"><span class="screen-reader-text">%s </span><span dir="ltr"%s>%s</span></p>',
-		__( 'Quote from Hello Dolly song, by Jerry Herman:', 'hello-dolly' ),
+		esc_html__( 'Quote from Hello Dolly song, by Jerry Herman:', 'hello-dolly' ),
 		$lang,
-		$chosen
+		esc_html( $chosen )
 	);
 }
 

--- a/hello.php
+++ b/hello.php
@@ -10,6 +10,8 @@ Description: This is not just a plugin, it symbolizes the hope and enthusiasm of
 Author: Matt Mullenweg
 Version: 1.7.2
 Author URI: http://ma.tt/
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 
 function hello_dolly_get_lyric() {

--- a/hello.php
+++ b/hello.php
@@ -46,7 +46,7 @@ Dolly'll never go away again";
 	$lyrics = explode( "\n", $lyrics );
 
 	// And then randomly choose a line.
-	return wptexturize( $lyrics[ mt_rand( 0, count( $lyrics ) - 1 ) ] );
+	return wptexturize( $lyrics[ wp_rand( 0, count( $lyrics ) - 1 ) ] );
 }
 
 // This just echoes the chosen line, we'll position it later.

--- a/hello.php
+++ b/hello.php
@@ -1,14 +1,14 @@
 <?php
 /**
  * @package Hello_Dolly
- * @version 1.7.2
+ * @version 1.7.3
  */
 /*
 Plugin Name: Hello Dolly
 Plugin URI: http://wordpress.org/plugins/hello-dolly/
 Description: This is not just a plugin, it symbolizes the hope and enthusiasm of an entire generation summed up in two words sung most famously by Louis Armstrong: Hello, Dolly. When activated you will randomly see a lyric from <cite>Hello, Dolly</cite> in the upper right of your admin screen on every page.
 Author: Matt Mullenweg
-Version: 1.7.2
+Version: 1.7.3
 Author URI: http://ma.tt/
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html

--- a/hello.php
+++ b/hello.php
@@ -60,7 +60,7 @@ function hello_dolly() {
 	printf(
 		'<p id="dolly"><span class="screen-reader-text">%s </span><span dir="ltr"%s>%s</span></p>',
 		esc_html__( 'Quote from Hello Dolly song, by Jerry Herman:', 'hello-dolly' ),
-		$lang,
+		$lang, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		esc_html( $chosen )
 	);
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,8 @@ Contributors: matt, wordpressdotorg
 Stable tag: 1.7.2
 Tested up to: 6.1
 Requires at least: 4.6
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 
 This is not just a plugin, it symbolizes the hope and enthusiasm of an entire generation summed up in two words sung most famously by Louis Armstrong.
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Hello Dolly ===
 Contributors: matt, wordpressdotorg
-Stable tag: 1.7.2
+Stable tag: 1.7.3
 Tested up to: 6.6
 Requires at least: 4.6
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Hello Dolly ===
 Contributors: matt, wordpressdotorg
 Stable tag: 1.7.2
-Tested up to: 6.1
+Tested up to: 6.6
 Requires at least: 4.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html


### PR DESCRIPTION
Per recent [plugin directory submission requirements](https://make.wordpress.org/plugins/2024/10/01/plugin-check-and-2fa-now-mandatory-for-new-plugin-submissions/), plugins that trigger any error level for [Plugin Check (PCP)](https://wordpress.org/plugins/plugin-check/) "Plugin Repo" category checks are barred from submission. Let's make sure Hello Dolly would pass the tests with PCP 1.2.0!

- Addresses use of `mt_rand()` in https://core.trac.wordpress.org/ticket/61215.
- Addresses output escaping flagged by the Security category checks.
- Adds GPLv2 or later license references.
- Updates tested up to for the latest version of WordPress.
- Bumps stable tag in GitHub to sync with the [latest in SVN](https://plugins.svn.wordpress.org/hello-dolly/tags/1.7.3/readme.txt) (a `stable_tag_mismatch` error occurs when [testing the plugin from the directory](https://playground.wordpress.net/?php=8.2&wp=6.6&networking=yes&plugin=plugin-check&plugin=hello-dolly&url=%2Fwp-admin%2Ftools.php%3Fpage%3Dplugin-check)).

Note: One check not resolved with this update is a warning for `plugin_header_invalid_plugin_uri_domain`. This occurs when the Plugin URI contains `wordpress.org`, but would not block submission on its own.

Props narenin, sergeybiryukov, ironprogrammer.
